### PR TITLE
feat: add pw:ui and pw:trace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "coverage:badge": "node scripts/generate-coverage-badge.mjs coverage/coverage-summary.json coverage/badge.json",
     "coverage:ci": "pnpm test:server:coverage && pnpm coverage:server:report && pnpm test:client:coverage && node scripts/normalize-coverage-summary.mjs .cache/coverage/client/coverage-summary.json && pnpm coverage:merge && pnpm coverage:badge",
     "dev:demo": "node scripts/dev-demo.mjs",
-    "dev:server": "node bin/jabterm-server.mjs"
+    "dev:server": "node bin/jabterm-server.mjs",
+    "pw:ui": "pnpm exec playwright test --ui",
+    "pw:trace": "pnpm exec playwright show-trace"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
Add convenience scripts for Playwright UI mode and trace viewer:

- `pnpm pw:ui` — launches Playwright in interactive UI mode
- `pnpm pw:trace` — opens Playwright trace viewer

Standardizes these scripts across all repos (`cc` and `browser2video` already have them).