### PR TITLE
JabTerm resize accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ CI also regenerates these assets on pushes to `main` (so contributors typically 
 | `className` | `string` | — | CSS class for the outer container |
 | `fontSize` | `number` | `13` | Font size in pixels |
 | `fontFamily` | `string` | system monospace | Font family |
+| `accessibilitySupport` | `"on" \| "off" \| "auto"` | — | xterm accessibility support mode (set to `"on"` if you need to read terminal text from the DOM for automation) |
 | `theme` | `{ background?, foreground?, cursor? }` | `{ background: "#1e1e1e" }` | xterm.js theme overrides |
 
 The outer container also exposes `data-jabterm-state="connecting|open|closed"` to make UI tests (e.g. Playwright) wait reliably.

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -45,6 +45,14 @@ export interface JabTermProps {
   fontSize?: number;
   /** Font family. Default: system monospace stack */
   fontFamily?: string;
+  /**
+   * xterm.js accessibility support mode.
+   *
+   * When set to `"on"`, xterm populates the accessibility tree (and in many setups
+   * also makes `.xterm-rows` contain textual content), which is useful for UI
+   * testing/automation that reads terminal output from the DOM.
+   */
+  accessibilitySupport?: "on" | "off" | "auto";
   /** xterm.js theme overrides. */
   theme?: {
     background?: string;


### PR DESCRIPTION
Implement resize message deduplication and pass `accessibilitySupport` prop to xterm.

Resize message deduplication prevents redundant `{type:"resize"}` frames from being sent, improving efficiency. The `accessibilitySupport` prop enables xterm's DOM-readable text/accessibility tree behavior.

---
<p><a href="https://cursor.com/agents?id=bc-c16e69c5-19e3-488d-a4f4-5698ad41ed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c16e69c5-19e3-488d-a4f4-5698ad41ed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

