### PR TITLE
JabTerm new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-02-22
+
+### Fixed
+
+- React: dedupe identical PTY resize messages (prevents redundant SIGWINCH / flicker). ([#22](https://github.com/holiber/jabterm/pull/22))
+- React: expose xterm `accessibilitySupport` option for DOM-readable text in canvas/WebGL mode. ([#22](https://github.com/holiber/jabterm/pull/22))
+
 ## [0.1.3] - 2026-02-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jabterm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "JabTerm - Just Another Browser Terminal. Drop-in React component + Node.js server.",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump package version to `v0.1.4` and update changelog to release recent fixes, including those from PR #22.

---
<p><a href="https://cursor.com/agents?id=bc-654681bf-5f69-4724-8e21-36ef15fbe4e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-654681bf-5f69-4724-8e21-36ef15fbe4e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

